### PR TITLE
fix: Refactor to provide slack message when canonical url is not resolved

### DIFF
--- a/src/tasks/opportunity-status-processor/handler.js
+++ b/src/tasks/opportunity-status-processor/handler.js
@@ -469,11 +469,9 @@ export async function runOpportunityStatusProcessor(message, context) {
     const needsScraping = requiredDependencies.has('scraping');
     const needsGSC = requiredDependencies.has('GSC');
 
-    // Only check data sources that are needed (all require siteUrl)
     if (!siteUrl) {
       log.warn('No siteUrl provided, skipping RUM, GSC, and scraping checks');
     } else {
-      // Resolve canonical URL (used by RUM and GSC - scraping uses siteUrl directly)
       let resolvedUrl = null;
       if (needsRUM || needsGSC) {
         resolvedUrl = await resolveCanonicalUrl(siteUrl);
@@ -487,19 +485,16 @@ export async function runOpportunityStatusProcessor(message, context) {
         }
       }
 
-      // Check RUM availability - use resolved URL if available, otherwise use base URL
       if (needsRUM) {
         const urlToCheck = resolvedUrl || siteUrl;
         const domain = new URL(urlToCheck).hostname;
         rumAvailable = await isRUMAvailable(domain, context);
       }
 
-      // Check GSC configuration - requires resolved URL
       if (needsGSC && resolvedUrl) {
         gscConfigured = await isGSCConfigured(resolvedUrl, context);
       }
 
-      // Check scraping availability - uses siteUrl directly, independent of resolved URL
       if (needsScraping) {
         const scrapingCheck = await isScrapingAvailable(siteUrl, context);
         scrapingAvailable = scrapingCheck.available;

--- a/src/tasks/opportunity-status-processor/handler.js
+++ b/src/tasks/opportunity-status-processor/handler.js
@@ -43,6 +43,15 @@ async function isRUMAvailable(domain, context) {
   const { log } = context;
   const rumClient = RUMAPIClient.createFrom(context);
 
+  try {
+    await rumClient.retrieveDomainkey(domain);
+    log.info(`RUM is available for domain: ${domain}`);
+    return true;
+  } catch (error) {
+    log.warn(`RUM is not available for domain: ${domain}. Reason: ${error.message}`);
+  }
+
+  // Try with www-toggled domain
   const wwwToggledDomain = toggleWWWHostname(domain);
   try {
     await rumClient.retrieveDomainkey(wwwToggledDomain);
@@ -51,15 +60,7 @@ async function isRUMAvailable(domain, context) {
   } catch (error) {
     log.warn(`RUM not available for ${wwwToggledDomain}: ${error.message}`);
   }
-
-  try {
-    await rumClient.retrieveDomainkey(domain);
-    log.info(`RUM is available for domain: ${domain}`);
-    return true;
-  } catch (error) {
-    log.warn(`RUM is not available for domain: ${domain}. Reason: ${error.message}`);
-    return false;
-  }
+  return false;
 }
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -203,5 +203,29 @@ describe('Index Tests', () => {
       expect(resp.status).to.equal(200);
       expect(directContext.log.info.calledWith(sinon.match(/Received message with type: dummy/))).to.be.true;
     });
+
+    it('detects wrapped SQS events with messageId in context.invocation.event.Records', async () => {
+      // Test case where event.Records is not present, but context.invocation.event.Records is
+      // This covers lines 111-112 in src/index.js
+      const wrappedSqsContext = {
+        ...context,
+        invocation: {
+          event: {
+            Records: [{
+              messageId: 'test-message-id-123',
+              body: JSON.stringify({
+                type: 'dummy',
+                siteId: 'wrapped-site',
+              }),
+            }],
+          },
+        },
+      };
+
+      // Pass an empty event object (no top-level Records)
+      const resp = await main({}, wrappedSqsContext);
+      expect(resp.status).to.equal(200);
+      expect(wrappedSqsContext.log.info.calledWith(sinon.match(/Received message with type: dummy/))).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
- Provide slack message when canonical url is not resolved.
- use base url for RUM api when canonical url is not resolved.
- remove try/catch block as it is not needed.
- Add toggle domain logic for RUM availability check

Discussion Thread:
https://cq-dev.slack.com/archives/C09HDEL271P/p1764874873793689?thread_ts=1764874781.547619&cid=C09HDEL271P

Test:
https://cq-dev.slack.com/archives/C060T2PPF8V/p1764982959614879
