### PR TITLE
fix: enforce curly braces and remove eslint-env comments

### DIFF
--- a/src/agents/brand-profile/services/product-extractor.js
+++ b/src/agents/brand-profile/services/product-extractor.js
@@ -76,7 +76,9 @@ const EXCLUDE_PATTERNS = [
  * @returns {number|null} Year as integer, or null
  */
 function extractYear(dateString) {
-  if (!dateString) return null;
+  if (!dateString) {
+    return null;
+  }
   try {
     if (dateString.includes('T')) {
       return parseInt(dateString.split('-')[0], 10);
@@ -94,7 +96,9 @@ function extractYear(dateString) {
  * @returns {string} Cleaned category string
  */
 function cleanCategory(typeLabel) {
-  if (!typeLabel) return '';
+  if (!typeLabel) {
+    return '';
+  }
   const clean = typeLabel.replace(/_/g, ' ');
   return clean.charAt(0).toUpperCase() + clean.slice(1).toLowerCase();
 }
@@ -219,7 +223,9 @@ async function queryWikidataProducts(wikidataId, log) {
  * @returns {object[]} Normalized items
  */
 function normalizeItems(items, status = 'current') {
-  if (!Array.isArray(items)) return [];
+  if (!Array.isArray(items)) {
+    return [];
+  }
 
   return items.map((item) => {
     if (typeof item === 'string') {

--- a/src/tasks/cwv-demo-suggestions-processor/handler.js
+++ b/src/tasks/cwv-demo-suggestions-processor/handler.js
@@ -220,7 +220,9 @@ async function processCWVOpportunity(opportunity, logger, env, slackContext) {
     const sayPromises = [];
 
     for (const suggestion of sortedSuggestions) {
-      if (suggestionsToUpdate.length >= MAX_CWV_DEMO_SUGGESTIONS) break;
+      if (suggestionsToUpdate.length >= MAX_CWV_DEMO_SUGGESTIONS) {
+        break;
+      }
 
       const data = suggestion.getData();
       const metrics = data.metrics || [];

--- a/test/agents/base.test.js
+++ b/test/agents/base.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import path from 'path';
 import fs from 'fs';
@@ -47,7 +45,9 @@ describe('agents/base utilities', () => {
     const unlink = (filePath) => {
       try {
         fs.unlinkSync(filePath);
-      } catch (e) { /* ignore */ }
+      } catch (e) {
+        /* ignore */
+      }
     };
 
     it('reads a file via relative path against static prompt dirname', () => {

--- a/test/agents/brand-profile/index.test.js
+++ b/test/agents/brand-profile/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/test/agents/brand-profile/services/competitor-inference.test.js
+++ b/test/agents/brand-profile/services/competitor-inference.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/test/agents/brand-profile/services/persona-inference.test.js
+++ b/test/agents/brand-profile/services/persona-inference.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/test/agents/brand-profile/services/product-extractor.test.js
+++ b/test/agents/brand-profile/services/product-extractor.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/test/agents/brand-profile/services/regional-context.test.js
+++ b/test/agents/brand-profile/services/regional-context.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/test/agents/brand-profile/services/wikipedia.test.js
+++ b/test/agents/brand-profile/services/wikipedia.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/test/agents/registry.test.js
+++ b/test/agents/registry.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/test/it/agent-executor/brand-profile.test.js
+++ b/test/it/agent-executor/brand-profile.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 /**
  * Manual integration test for running the brand-profile agent through the agent executor.
  *

--- a/test/tasks/agent-executor/agent-executor.test.js
+++ b/test/tasks/agent-executor/agent-executor.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';

--- a/test/tasks/cwv-demo-suggestions-processor/cwv-demo-suggestions-processor.test.js
+++ b/test/tasks/cwv-demo-suggestions-processor/cwv-demo-suggestions-processor.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import esmock from 'esmock';

--- a/test/tasks/demo-url-processor/demo-url-processor.test.js
+++ b/test/tasks/demo-url-processor/demo-url-processor.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { MockContextBuilder } from '../../shared.js';

--- a/test/tasks/disable-import-audit-processor/disable-import-audit-processor.test.js
+++ b/test/tasks/disable-import-audit-processor/disable-import-audit-processor.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/test/tasks/opportunity-status-processor/opportunity-status-processor.test.js
+++ b/test/tasks/opportunity-status-processor/opportunity-status-processor.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/test/tasks/slack-notify/slack-notify.test.js
+++ b/test/tasks/slack-notify/slack-notify.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';

--- a/test/utils/slack-utils.test.js
+++ b/test/utils/slack-utils.test.js
@@ -10,8 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-/* eslint-env mocha */
-
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';


### PR DESCRIPTION
## Summary
- Remove `curly: off` override from eslint config
- Expand single-line if/while/for bodies to multi-line with braces  
- Remove redundant `/* eslint-env */` comments

Companion to adobe/spacecat-shared#1521.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes