### PR TITLE
ci: opt in to upstream bundle-build smoke check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,4 +17,5 @@ jobs:
     with:
       service-name: task-processor
       vpc-enabled: true
+      bundle-build: true
     secrets: inherit


### PR DESCRIPTION
## Summary

Sets `bundle-build: true` on the reusable `service-ci.yaml@v2` workflow. The new step `Build Lambda bundle (smoke check)` runs `npm run build` (= helix-deploy `--test-bundle`) — it bundles the Lambda artifact, zips it, and invokes the bundled `lambda()` against a synthetic healthcheck event, exiting non-zero on any non-2xx response.

This catches the class of failure where source-based unit tests stay green but the bundled artifact crashes at cold start. Source tests resolve `import.meta.url` to the original source path; the bundled artifact does not. Missing static assets, top-level FS side-effects, ESM/CJS interop regressions, and module-load `TypeError`s all live in this gap.

`spacecat-task-processor` declares static assets under `hlx.static` (`static/prompts/`, `static/cls*.md`, `static/inp*.md`, `static/lcp*.md`) — exactly the SITES-45260 risk class — so the gate is meaningfully load-bearing for this repo.

## Why

The gate was first implemented as a repo-local job in adobe/spacecat-api-service#2466 after [SITES-45260](https://jira.corp.adobe.com/browse/SITES-45260) (the semrush AIO proxy that took down api-service Lambda for every invocation). adobe/mysticat-ci#17 lifted it into the reusable workflow so the rest of the spacecat Lambda services inherit the same defence.

This PR is one of the Phase 2 opt-in rollout PRs documented at https://github.com/adobe/mysticat-ci/pull/17#issuecomment-4563972002. `task-processor` was missed in the initial scope list (it isn't in the workspace's default repo groups, so it slipped through the local-clone sanity check); the audit re-run via `gh search code service-ci.yaml@v2 org:adobe` surfaced it.

## Verification

- [ ] CI run on this PR completes.
- [ ] New step `Build Lambda bundle (smoke check)` appears in the `build` job log.
- [ ] Step exits 0.

If the gate fires on this PR with a real bundling bug, that's the gate doing its job — fix the bug in this PR rather than dropping the opt-in.

## Cross-references

- adobe/mysticat-ci#17 — upstream lift PR
- [adobe/mysticat-ci@v2.2.0](https://github.com/adobe/mysticat-ci/releases/tag/v2.2.0) — release that ships the new input
- adobe/spacecat-api-service#2466 — original repo-local gate (SITES-45260)

🤖 Generated with [Claude Code](https://claude.com/claude-code)