### PR TITLE
fix(onboard-status): show no-scrape-data scraping state as neutral, not failed

### DIFF
--- a/src/tasks/opportunity-status-processor/handler.js
+++ b/src/tasks/opportunity-status-processor/handler.js
@@ -606,11 +606,16 @@ export async function runOpportunityStatusProcessor(message, context) {
     const seoImportStatus = seoImportAvailable ? ':white_check_mark:' : ':x:';
     const gscStatus = gscConfigured ? ':white_check_mark:' : ':x:';
     // Tri-state scraping: hourglass while URLs are still being scraped, so an
-    // in-progress snapshot is not mislabelled as a failure.
+    // in-progress snapshot is not mislabelled as a failure. 'unknown' (no scrape data
+    // yet) shows a neutral info icon — not ❌ (which would falsely read as failed) and
+    // not ⏳ (which would overclaim active progress). Only a genuinely terminal-failed
+    // scrape (0 completed, 0 pending, >0 failed) shows ❌.
     const scrapingStatusKey = deriveScrapingStatus(scrapingStats);
     const scrapingEmoji = {
       available: ':white_check_mark:',
       in_progress: ':hourglass_flowing_sand:',
+      unknown: ':information_source:',
+      failed: ':x:',
     }[scrapingStatusKey] || ':x:';
     const scrapingStatus = scrapingEmoji;
 


### PR DESCRIPTION
## Follow-up to #340 (merged)

Small correctness fix on the onboarding status report's scraping data-source line.

**Problem:** the `unknown` scraping state — no scrape data yet (`getScrapingStats`/`isScrapingAvailable` found no jobs or no URL results for the current onboarding) — mapped to ❌. On an early snapshot of a not-yet-scraped site that reads as a **failure**, the exact running-vs-failed conflation #340 set out to remove. It also contradicted the accompanying "_Scraping is in progress or no results available yet_" text.

**Fix:** map `unknown` to a neutral **ℹ️** (`:information_source:`) — not ❌ (false failure) and not ⏳ (which would overclaim active progress). A genuinely terminal-failed scrape (0 completed, 0 pending, >0 failed) still resolves to ❌ via the tri-state; `in_progress` (URLs pending) stays ⏳; `available` stays ✅.

Surfaced by review of the sibling change in spacecat-api-service ([#2974](https://github.com/adobe/spacecat-api-service/pull/2974)); this keeps the two `deriveScrapingStatus` consumers in sync.

## Tests
Full suite green (**415 passing**), coverage gate passes, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
